### PR TITLE
Add interactive-widget meta tag

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,10 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0, interactive-widget=resizes-content"
+    />
     <title>Cyberpunk Scratchcard</title>
   </head>
   <body>


### PR DESCRIPTION
Add `interactive-widget=resizes-content` to fix the issue of wrong viewport height on initial page load on Chrome (Android)

Reference: 
https://github.com/Zwyx/chrome-android-clientheight
https://developer.chrome.com/blog/viewport-resize-behavior/